### PR TITLE
es-de: get rid of installPhase, set some compile flags, expand meta

### DIFF
--- a/pkgs/by-name/em/emulationstation-de/001-add-nixpkgs-retroarch-cores-unix.patch
+++ b/pkgs/by-name/em/emulationstation-de/001-add-nixpkgs-retroarch-cores-unix.patch
@@ -1,0 +1,18 @@
+--- a/resources/systems/unix/es_find_rules.xml	2023-11-22 15:18:15.912747163 -0500
++++ b/resources/systems/unix/es_find_rules.xml	2023-11-22 15:20:38.628250448 -0500
+@@ -45,6 +45,8 @@
+             <entry>/usr/local/lib/libretro</entry>
+             <!-- NetBSD repository -->
+             <entry>/usr/pkg/lib/libretro</entry>
++            <!-- NixOS / Nixpkgs -->
++            <entry>/run/current-system/sw/lib/retroarch/cores</entry>
+         </rule>
+     </core>
+     <emulator name="3DSEN-WINDOWS">
+@@ -1079,4 +1081,4 @@
+             <entry>~/bin/ZEsarUX/zesarux</entry>
+         </rule>
+     </emulator>
+-</ruleList>
+\ No newline at end of file
++</ruleList>

--- a/pkgs/by-name/em/emulationstation-de/002-add-nixpkgs-retroarch-cores-linux.patch
+++ b/pkgs/by-name/em/emulationstation-de/002-add-nixpkgs-retroarch-cores-linux.patch
@@ -1,0 +1,18 @@
+--- a/resources/systems/linux/es_find_rules.xml	1970-01-01 05:00:01.000000000 +0500
++++ b/resources/systems/linux/es_find_rules.xml	2024-06-13 19:23:15.428157651 +0500
+@@ -41,6 +41,8 @@
+             <entry>/usr/lib64/libretro</entry>
+             <!-- Manjaro repository -->
+             <entry>/usr/lib/libretro</entry>
++            <!-- NixOS / Nixpkgs -->
++            <entry>/run/current-system/sw/lib/retroarch/cores</entry>
+         </rule>
+     </core>
+     <emulator name="3DSEN-WINDOWS">
+@@ -1102,4 +1104,4 @@
+             <entry>~/bin/ZEsarUX/zesarux</entry>
+         </rule>
+     </emulator>
+-</ruleList>
+\ No newline at end of file
++</ruleList>

--- a/pkgs/by-name/em/emulationstation-de/package.nix
+++ b/pkgs/by-name/em/emulationstation-de/package.nix
@@ -28,7 +28,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  patches = [ ./001-add-nixpkgs-retroarch-cores.patch ];
+  patches = [
+    ./001-add-nixpkgs-retroarch-cores-unix.patch
+    ./002-add-nixpkgs-retroarch-cores-linux.patch
+  ];
 
   nativeBuildInputs = [
     cmake
@@ -48,11 +51,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Release"
-    
+
     # By default the application updater will be built
     # which checks for new releases on startup, this disables it.
     "-DAPPLICATION_UPDATER=off"
-    
+
     # Sets the installation directory, also modifies code inside ES-DE
     # used to locate the required program resources. Though I builds
     # correctly without it.

--- a/pkgs/by-name/em/emulationstation-de/package.nix
+++ b/pkgs/by-name/em/emulationstation-de/package.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   outputs = [ "out" "man" ];
 
+  strictDeps = true;
+
   patches = [ ./001-add-nixpkgs-retroarch-cores.patch ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
It builds on my machine, all assets (icons, desktop file, license, resource folder, etc) are exported aa expected. Please tell me if it doesn't build on yours. There's also `es-pdf-convert` in `$out/bin` which can be somehow exposed to user.

Sorry for all the style changes. They were convenient for me, revert them if you wish.

## Description of changes
Removed `installPhase` (it will be done automatically) and set some compile flags (one of them removes application updater, for example). Added myself as maintainer because I'm interested in this package (feel free to remove me if that's a problem).

P.s.: it was already built from source, so stupid me. But there are still some improvements in this PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
